### PR TITLE
4098 vanta update tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Untagged]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,8 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
-## []
+## [WW_20241101114424]
+
+### Changed
+
+- Make tags optional by  adding default empty tags

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "name" {
 }
 variable "tags" {
   type = map(string)
-  default = null
+  default = {}
 }
 variable "env" {
   type = string

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,7 @@ variable "name" {
 }
 variable "tags" {
   type = map(string)
+  default = {}
 }
 variable "env" {
   type = string

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "name" {
 }
 variable "tags" {
   type = map(string)
-  default = {}
+  default = null
 }
 variable "env" {
   type = string


### PR DESCRIPTION
Made tags optional by adding a null default

## Author Checklist

- [x] I validated this in QA or have noted below why it cannot

## Release Notes

- [ ] Includes a migration
- [ ] Migration is [Zero Downtime](https://docs.gitlab.com/ee/development/database/avoiding_downtime_in_migrations.html)
- [ ] Includes Infrastructure Changes

## Reviewer Checklist

- [ ] Follows [best practices](https://github.com/Widewail/engineering-docs/wiki/BestPractices)
- [ ] No large transaction boundaries
- [ ] Queued messages published outside of transactions (if applicable)
- [ ] API calls happen outside of transactions (if applicable)

**This file is managed by [this template](https://github.com/Widewail/.github/edit/master/pull_request_template.md)**
